### PR TITLE
Restore opening UserScript comments

### DIFF
--- a/NM trade enhancement.user.js
+++ b/NM trade enhancement.user.js
@@ -1,3 +1,5 @@
+// ==UserScript==
+// @name         NM trade enhancement
 // @namespace    7nik
 // @version      1.2.3
 // @description  Adds enhancements to the trading window


### PR DESCRIPTION
A couple versions back the first two comment lines were dropped, and since them TamperMonkey (at least that's what I use) has considered the entire script to be invalid. :man_shrugging: 

This patch just restores those first two lines that were [lost in the 1.2 release](https://github.com/7nik/userscripts/commit/8e4fac4adcf93dd02f46e1452711993e23c1d9c3#diff-719f67824cf9fe049af4fd7f224710ac).