### PR TITLE
📚 Stop Print Chooser from propagating the click event.

### DIFF
--- a/NM trade enhancement.user.js
+++ b/NM trade enhancement.user.js
@@ -1482,6 +1482,9 @@ async function addPrintChooser (card) {
         .map(({ print_num: num, id }) => `<option value="${id}" label="#${num}">#${num}</option>`)
         .join();
     select.options[prints.findIndex(({ print_num: num }) => num === printNum)].selected = true;
+    select.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+    });
     select.addEventListener("change", (ev) => {
         // in fact, we need update the variable _selectedIds but we don't have access to it
         // so we make re-adding card with updated data


### PR DESCRIPTION
When clicking the Print Chooser, before I was able to choose the print I want, the click event was causing a re-render. The re-render would close the select, preventing me from clicking the print.